### PR TITLE
[FEAT] 지역명 api 연결 & 사용자 지역 선택

### DIFF
--- a/src/components/AreacodeAPI/index.js
+++ b/src/components/AreacodeAPI/index.js
@@ -1,28 +1,36 @@
-import React from 'react';
+import React, {useState} from 'react';
 import axios from "axios";
 
-const AreacodeAPI = () => {
+const AreacodeAPI = async (areacode) => {
 
   const API_KEY = process.env.REACT_APP_AREACODE_API_KEY;
   const url = "http://api.visitkorea.or.kr/openapi/service/rest/KorService/areaCode";
 
-  axios
+  // 지역코드로 조회한 지역 결과 리스트
+  let areaItems = [];
+
+  await axios
       .get(url,{
         params: {
           ServiceKey: API_KEY,
-          numOfRows: 10,
+          numOfRows: 20,
           pageNo: 1,
           MobileOS: "WIN",
           MobileApp: "CaT",
-          areaCode: 1
+          areaCode: areacode
         },
       })
       .then((res) => {
-        console.log("👍지역코드 조회 api 호출 성공", res);
+        console.log("👍지역코드 조회 api 호출 성공", res.data);
+        areaItems = res.data.response.body.items['item'];
       })
       .catch((err) => {
         console.log("🧨지역코드 조회 api 호출 실패", err);
       })
+
+  console.log(areaItems);
+
+  return areaItems;
 }
 
 export default AreacodeAPI;

--- a/src/components/AreacodeAPI/index.js
+++ b/src/components/AreacodeAPI/index.js
@@ -1,0 +1,28 @@
+import React from 'react';
+import axios from "axios";
+
+const AreacodeAPI = () => {
+
+  const API_KEY = process.env.REACT_APP_AREACODE_API_KEY;
+  const url = "http://api.visitkorea.or.kr/openapi/service/rest/KorService/areaCode";
+
+  axios
+      .get(url,{
+        params: {
+          ServiceKey: API_KEY,
+          numOfRows: 10,
+          pageNo: 1,
+          MobileOS: "WIN",
+          MobileApp: "CaT",
+          areaCode: 1
+        },
+      })
+      .then((res) => {
+        console.log("👍지역코드 조회 api 호출 성공", res);
+      })
+      .catch((err) => {
+        console.log("🧨지역코드 조회 api 호출 실패", err);
+      })
+}
+
+export default AreacodeAPI;

--- a/src/components/GoCampingAPI/index.js
+++ b/src/components/GoCampingAPI/index.js
@@ -3,29 +3,29 @@ import axios from "axios";
 
 export const SpotBasedSearch = (x,y) => {
 
-  const API_KEY = process.env.REACT_APP_OPEN_API_KEY;
+  const API_KEY = process.env.REACT_APP_GOCAMPING_API_KEY;
   const url = "http://api.visitkorea.or.kr/openapi/service/rest/GoCamping/locationBasedList";
 
 
-    axios
-        .get(url, {
-          params: {
-            ServiceKey: API_KEY,
-            // pageNo: 1,
-            // numOfRows: 10,
-            MobileOS: "WIN",
-            MobileApp: "CaT",
-            mapX: x,  // ex
-            mapY: y,   // ex
-            radius: 2000
-          }
-        })
-        .then((res) => {
-          console.log("👍고캠핑 api 연결 성공\n", res);
-          console.log(x,y);
-        })
-        .catch((err) => {
-          console.log("🧨고캠핑 api 연결 실패\n", err);
-        })
+  axios
+      .get(url, {
+        params: {
+          ServiceKey: API_KEY,
+          // pageNo: 1,
+          // numOfRows: 10,
+          MobileOS: "WIN",
+          MobileApp: "CaT",
+          mapX: x,  // ex
+          mapY: y,   // ex
+          radius: 2000
+        }
+      })
+      .then((res) => {
+        console.log("👍고캠핑 api 연결 성공\n", res);
+        console.log(x,y);
+      })
+      .catch((err) => {
+        console.log("🧨고캠핑 api 연결 실패\n", err);
+      })
 
 };

--- a/src/components/Map/index.js
+++ b/src/components/Map/index.js
@@ -15,9 +15,9 @@ export const KakaoMapAPI = () => {
 };
 
 
-export const KakaoSpotBasedSearch = async () => {
+export const KakaoSpotBasedSearch = async (spotText) => {
 
-  console.log("👍카카오 주소 검색 연결");
+  console.log("👍카카오 주소 검색 연결: ", spotText);
 
   const [mapX, setMapX] = useState(37.4917882876857);
   const [mapY, setMapY] = useState(127.487578470072);
@@ -26,7 +26,7 @@ export const KakaoSpotBasedSearch = async () => {
   const geocoder = new kakao.maps.services.Geocoder();
 
   // 주소로 좌표를 검색합니다
-  geocoder.addressSearch('전라도 전주', await function(result, status) {
+  geocoder.addressSearch(spotText, await function(result, status) {
 
     // 정상적으로 검색이 완료됐으면
     if (status === kakao.maps.services.Status.OK) {
@@ -34,7 +34,7 @@ export const KakaoSpotBasedSearch = async () => {
       const coords = new kakao.maps.LatLng(result[0].y, result[0].x);
       setMapX(Number(result[0].y));
       setMapY(Number(result[0].x));
-      console.log("result[0]: ", result[0].y, result[0].x);
+      // console.log("result[0]: ", result[0].y, result[0].x);
 
       // 결과값으로 받은 위치를 마커로 표시합니다
       const marker = new kakao.maps.Marker({
@@ -44,7 +44,7 @@ export const KakaoSpotBasedSearch = async () => {
 
       // 인포윈도우로 장소에 대한 설명을 표시합니다
       const infowindow = new kakao.maps.InfoWindow({
-        content: '<div style="width:150px;text-align:center;padding:6px 0;">우리회사</div>'
+        content: '<div style="width:150px;text-align:center;padding:6px 0;">검색위치</div>'
       });
       infowindow.open(map, marker);
 

--- a/src/pages/AllCampsite/index.js
+++ b/src/pages/AllCampsite/index.js
@@ -3,6 +3,7 @@ import Header from "../../components/Header";
 import {SpotBasedSearch} from "../../components/GoCampingAPI/index";
 import {MapWrapper, ResultWrapper, SearchInputWrapper, Wrapper} from "./style";
 import {KakaoMapAPI, KakaoSpotBasedSearch} from "../../components/Map";
+import AreacodeAPI from "../../components/AreacodeAPI";
 
 
 const AllCampsite = () => {
@@ -13,27 +14,24 @@ const AllCampsite = () => {
   // 카카오맵 불러오기
   useEffect(() => {
     KakaoMapAPI();
+    AreacodeAPI();
   },[]);
 
 
 
   async function callSpotBasedSearch() {
-    const loc = await KakaoSpotBasedSearch();
-    console.log("tmpX, tmpY: ", loc);
-    return loc;
+    return await KakaoSpotBasedSearch();
   }
 
   // SpotBasedSearch({mapX, mapY});
   callSpotBasedSearch()
       .then((res) => {
-        console.log("promise res: ", res[0], res[1]);
         setMapX(res[0]);
         setMapY(res[1]);
       })
       .catch((err) => {
         console.log(err);
       })
-  console.log("onclick: ", mapX, mapY);
 
   const onClickSearch = useCallback(() => {
     SpotBasedSearch(mapX, mapY);
@@ -46,6 +44,9 @@ const AllCampsite = () => {
         <Wrapper>
           <MapWrapper id="kakao-map"/>
           <SearchInputWrapper>
+            <select>
+
+            </select>
             <input />
             <input />
             <input />

--- a/src/pages/AllCampsite/index.js
+++ b/src/pages/AllCampsite/index.js
@@ -8,22 +8,57 @@ import AreacodeAPI from "../../components/AreacodeAPI";
 
 const AllCampsite = () => {
 
+  // 검색 좌표
   const [mapX, setMapX] = useState(33.4506810661721);
   const [mapY, setMapY] = useState(126.57049341667);
+  // 지역코드
+  const [areaCode, setAreaCode] = useState(null);
+  const [selectedLocal1, setSelectedLocal1] = useState("");
+  const [selectedLocal2, setSelectedLocal2] = useState("");
+  // 지역명
+  const [selectedLocalText1, setSelectedLocalText1] = useState("");
+  const [selectedLocalText2, setSelectedLocalText2] = useState("");
+  // 지역코드1로 조회한 지역 결과 리스트
+  const [area1Items, setArea1Items] = useState([]);
+  // 지역코드2로 조회한 지역 결과 리스트
+  const [area2Items, setArea2Items] = useState([]);
 
   // 카카오맵 불러오기
   useEffect(() => {
     KakaoMapAPI();
-    AreacodeAPI();
   },[]);
 
+  // 지역 코드1 불러오기
+  useEffect(() => {
+    AreacodeAPI(null)
+        .then((res) => {
+          setArea1Items(res);
+        })
+        .catch((err) => {
+          console.log(err);
+        })
+  },[]);
+
+  // 지역 코드2 불러오기
+  useEffect(() => {
+    if(areaCode === '8') {
+      setArea2Items([]);
+      return;
+    }
+    AreacodeAPI(areaCode)
+        .then((res) => {
+          setArea2Items(res);
+        })
+        .catch((err) => {
+          console.log(err);
+        })
+  },[areaCode]);
 
 
   async function callSpotBasedSearch() {
-    return await KakaoSpotBasedSearch();
+    return await KakaoSpotBasedSearch(selectedLocalText1 + " " + selectedLocalText2);
   }
 
-  // SpotBasedSearch({mapX, mapY});
   callSpotBasedSearch()
       .then((res) => {
         setMapX(res[0]);
@@ -32,6 +67,24 @@ const AllCampsite = () => {
       .catch((err) => {
         console.log(err);
       })
+
+  // 지역1 선택
+  const SelectLocal1 = (e) => {
+    // console.log(e.target.options[e.target.selectedIndex].text);
+    const text = e.target.options[e.target.selectedIndex].text;
+    setSelectedLocal1(e.target.value);
+    setSelectedLocalText1(text);
+    setAreaCode(e.target.value);
+    setSelectedLocal2("");
+  };
+
+  // 지역2 선택
+  const SelectLocal2 = (e) => {
+    // console.log(e.target.options[e.target.selectedIndex].text);
+    const text = e.target.options[e.target.selectedIndex].text;
+    setSelectedLocal2(e.target.value);
+    setSelectedLocalText2(text);
+  };
 
   const onClickSearch = useCallback(() => {
     SpotBasedSearch(mapX, mapY);
@@ -44,11 +97,18 @@ const AllCampsite = () => {
         <Wrapper>
           <MapWrapper id="kakao-map"/>
           <SearchInputWrapper>
-            <select>
-
+            <select onChange={SelectLocal1} value={selectedLocal1}>
+              <option value="">--지역1--</option>
+              {area1Items.map((item) => {
+                return <option key={item.rnum} value={item.code}>{item.name}</option>
+              })}
             </select>
-            <input />
-            <input />
+            <select onChange={SelectLocal2} value={selectedLocal2}>
+              <option value="">--지역2--</option>
+              {area2Items.map((item) => {
+                return <option key={item.rnum} value={item.code}>{item.name}</option>
+              })}
+            </select>
             <input />
             <button onClick={onClickSearch}>입력</button>
           </SearchInputWrapper>


### PR DESCRIPTION
## feat/camping-list -> main✨

## PR 타입(하나 이상의 PR 타입을 선택해주세요)🛠
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 구현 내용✏
- 한국관광공사_국문 관광정보 서비스 api 연결 => 지역명 api 받아오기
- 사용자가 지역명을 선택(도-시군구) -> 문자열로 카카오 주소 검색 api에 연결 -> 좌표값 받아온 후 고캠핑 api에 좌표값 전달 -> 전달받은 좌표값으로 해당 지역 고캠핑 데이터 검색 완료

## Screenshots🎨

## 유의사항🧨

- [ ] 인포윈도우의 장소 설명 표시값 수정 필요