### PR TITLE
[FIX] 상세 캠핑장 대표 이미지만 나타내기로 수정

### DIFF
--- a/src/pages/ContentDetail/index.js
+++ b/src/pages/ContentDetail/index.js
@@ -125,9 +125,7 @@ const ContentDetail = () => {
               <Title>{Campsite.facltNm}</Title>
               {/* 이미지 */}
               <ImgsWrapper>
-                <StyledBtn>◀ ︎prev</StyledBtn>
                 <img src={Campsite.firstImageUrl} alt="대표이미지" />
-                <StyledBtn>next ▶︎</StyledBtn>
               </ImgsWrapper>
 
               <LeftInfo>주소: {Campsite.addr1} {Campsite.addr2}</LeftInfo>

--- a/src/pages/ContentDetail/style.js
+++ b/src/pages/ContentDetail/style.js
@@ -26,6 +26,7 @@ export const LeftWrapper = styled.div`
 export const Title = styled.p`
   font-size: x-large;
   font-weight: bold;
+  margin-bottom: 0;
 `
 
 export const LeftInfo = styled.span`
@@ -37,7 +38,7 @@ export const LeftInfo = styled.span`
 export const Map = styled.div`
   width: 100%;
   height: 300px;
-  margin: 10px 0;
+  margin: 20px 0 10px;
   border: 1px solid;  // 임시
 `
 
@@ -51,14 +52,12 @@ export const RightWrapper = styled.div`
 
 export const ImgsWrapper = styled.div`
   display: flex;
-  justify-content: space-between;
-  align-items: center;
+  justify-content: center;
 
   margin: 10px 0;
   
   & > img {
-    width: 80%;
-    height: 80%;
+    width: 100%;
     object-fit: contain;
   }
 `


### PR DESCRIPTION
## campsite-detail -> main✨

## PR 타입(하나 이상의 PR 타입을 선택해주세요)🛠
- [ ] 기능 추가
- [x] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 구현 내용✏
- 상세 캠핑장 이미지 - api 연결해서 여러 이미지 나타내기X, 대표 이미지만 보이기로 수정

## Screenshots🎨
![image](https://user-images.githubusercontent.com/78535339/186952360-1af28fe2-6746-4baf-9d7e-ee148fd9c1da.png)


## 유의사항🧨
- 관광사진 api 연결 안하기로 수정
